### PR TITLE
Update OpenSSL to 3.1.2

### DIFF
--- a/deps/OpenSSL/OpenSSL.cmake
+++ b/deps/OpenSSL/OpenSSL.cmake
@@ -40,10 +40,8 @@ endif()
 
 ExternalProject_Add(dep_OpenSSL
     #EXCLUDE_FROM_ALL ON
-    URL "https://github.com/openssl/openssl/archive/OpenSSL_1_1_1w.tar.gz"
-    URL_HASH SHA256=2130E8C2FB3B79D1086186F78E59E8BC8D1A6AEDF17AB3907F4CB9AE20918C41
-    # URL "https://github.com/openssl/openssl/archive/refs/tags/openssl-3.1.2.tar.gz"
-    # URL_HASH SHA256=8c776993154652d0bb393f506d850b811517c8bd8d24b1008aef57fbe55d3f31
+    URL "https://github.com/openssl/openssl/archive/refs/tags/openssl-3.1.2.tar.gz"
+    URL_HASH SHA256=8c776993154652d0bb393f506d850b811517c8bd8d24b1008aef57fbe55d3f31
     DOWNLOAD_DIR ${DEP_DOWNLOAD_DIR}/OpenSSL
 	CONFIGURE_COMMAND ${_conf_cmd} ${_cross_arch}
         "--openssldir=${DESTDIR}"


### PR DESCRIPTION
## Summary
- update OpenSSL archive URL to version 3.1.2 and adjust hash

## Testing
- `cmake -S deps -B deps/buildtest -G Ninja -DDESTDIR=/tmp/destdir -DDEP_DOWNLOAD_DIR=/tmp/dlcache` *(fails: Could NOT find OpenGL)*
- `./BuildLinux.sh -d -r` *(fails: Could NOT find OpenGL)*


------
https://chatgpt.com/codex/tasks/task_b_6842f745f7008322bfed9c9111a89e1e